### PR TITLE
Don't make any OpenAL calls if -noaudio option is used.

### DIFF
--- a/ai/context.c
+++ b/ai/context.c
@@ -39,6 +39,7 @@ int ai_context_create(struct cen64_ai_context *context) {
     alcMakeContextCurrent(NULL);
     alcDestroyContext(context->ctx);
     alcCloseDevice(context->dev);
+    return 1;
   }
 
   alGenSources(1, &context->source);
@@ -50,6 +51,7 @@ int ai_context_create(struct cen64_ai_context *context) {
     alcMakeContextCurrent(NULL);
     alcDestroyContext(context->ctx);
     alcCloseDevice(context->dev);
+    return 1;
   }
 
   // Queue/prime buffers, clear them to prevent pops.


### PR DESCRIPTION
Also returns error if some OpenAL initialization fails
during ai_context_create().